### PR TITLE
fix: set dashboard title text color for light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div class="container mx-auto p-4 md:p-6 lg:p-8">
         
         <header class="mb-6">
-            <h1 class="text-3xl md:text-4xl font-bold text-white mb-2">QQQ 成分股追蹤儀表板</h1>
+            <h1 class="text-3xl md:text-4xl font-bold text-black dark:text-white mb-2">QQQ 成分股追蹤儀表板</h1>
             <div class="flex justify-between items-center">
                 <p class="text-gray-400">即時追蹤、排序並透過 AI 分析 Nasdaq 100 最新動態。</p>
                 <div class="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- ensure dashboard title uses black text in light theme and white text in dark theme

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a117a844832c90c67f878dfe208b